### PR TITLE
Improvement: Constant livestream URL

### DIFF
--- a/api/v1/utils/tools/streamNotification.js
+++ b/api/v1/utils/tools/streamNotification.js
@@ -17,10 +17,10 @@ module.exports = function(body, homeContent) {
     return fetch(URL)
           .then(res => res.json())
           .then(json => {
+            webhook.send(`Striimi live! \n https://www.youtube.com/c/Misikaani/live`);
             if(json.items[0]) {
               const info = json.items[0];
               homeContent.findOneAndUpdate({type: 'latestStream'}, {$set: {value: info.id.videoId}});
-              webhook.send(`Striimi live! \n https://www.youtube.com/c/Misikaani/live`);
               return { msg: 'Sent notification' };
             } else {
               return { msg: "Stream isn't live"};

--- a/api/v1/utils/tools/streamNotification.js
+++ b/api/v1/utils/tools/streamNotification.js
@@ -20,7 +20,7 @@ module.exports = function(body, homeContent) {
             if(json.items[0]) {
               const info = json.items[0];
               homeContent.findOneAndUpdate({type: 'latestStream'}, {$set: {value: info.id.videoId}});
-              webhook.send(`Striimi live! \n https://youtube.com/watch?v=${info.id.videoId}`);
+              webhook.send(`Striimi live! \n https://www.youtube.com/c/Misikaani/live`);
               return { msg: 'Sent notification' };
             } else {
               return { msg: "Stream isn't live"};


### PR DESCRIPTION
Changed livestream notification to use the constant /live URL, rather
than a direct video link.